### PR TITLE
Issue #12

### DIFF
--- a/cosolvkit/cosolvent_system.py
+++ b/cosolvkit/cosolvent_system.py
@@ -705,9 +705,11 @@ class CosolventSystem(object):
         for cosolvent in cosolvents:
             print(f"Placing {cosolvent.copies} copies of {cosolvent.name}")
             c_xyz = cosolvents[cosolvent]
-            for replicate in range(cosolvent.copies):
-                counter = replicate
+            while len(cosolv_xyzs[cosolvent]) < cosolvent.copies:
+            # for replicate in range(cosolvent.copies):
+                # counter = replicate
                 if len(placed_atoms_positions) < 1:
+                    counter = 0
                     xyz = points[counter]
                     cosolv_xyz = c_xyz + xyz
                     if self.check_coordinates_to_add(cosolv_xyz, None, prot_kdtree):


### PR DESCRIPTION
The problem is in the conversion from `openff Topology` to `openmm Topology`.
Since version 0.12 `openff` assigns a different chain to each residue in the topology when converting to `openmm`. The soultion that i adopted is to modify the function to convert `openff Topology` to `openmm Topology` and wrapping it inside `CosolventSystem` class.