### PR TITLE
issue #17

### DIFF
--- a/cosolvkit/cli/create_cosolvent_system.py
+++ b/cosolvkit/cli/create_cosolvent_system.py
@@ -166,6 +166,7 @@ def main():
                         positions = pos,
                         pdb = pdb,
                         system = system,
+                        membrane_protein = config.membrane,
                         traj_write_freq = args.traj_write_freq,
                         time_step = args.time_step,
                         warming_steps = 100000,


### PR DESCRIPTION
Addressed issue #17.
Now the run_simulation function takes as input the membrane boolean from the config file and if it is `True` the barostat added is of the type `MonteCarloMembraneBarostat` otherwise it uses the normal one.