### PR TITLE
do not set non-existent DeterministicForces on OpenCL

### DIFF
--- a/cosolvkit/simulation.py
+++ b/cosolvkit/simulation.py
@@ -70,7 +70,6 @@ def run_simulation( simulation_format: str = 'OPENMM',
     except: 
         try:
             platform = openmm.Platform.getPlatformByName("OpenCL")
-            platform.setPropertyDefaultValue('DeterministicForces', 'true')
             platform.setPropertyDefaultValue('Precision', 'mixed')
             print('Using GPU:OpenCL')
         except:


### PR DESCRIPTION
Option "DeterministicForces" does not exist for OpenCL platform.

http://docs.openmm.org/latest/userguide/library/04_platform_specifics.html